### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -272,7 +272,12 @@ async function createBatchZip(participants) {
       
       // Update certificate with participant data
       certName.textContent = p.name;
-      certEvent.innerHTML = `has successfully participated in <strong>${p.event}</strong>`;
+      // Safely set event text while preserving <strong> styling
+      certEvent.textContent = '';
+      certEvent.appendChild(document.createTextNode('has successfully participated in '));
+      const strongEvent = document.createElement('strong');
+      strongEvent.textContent = p.event;
+      certEvent.appendChild(strongEvent);
       certDate.textContent = p.date;
       certIssuer.textContent = p.issuer;
       cert.className = `certificate ${certTemplate}`;


### PR DESCRIPTION
Potential fix for [https://github.com/NITHIN9526/certificate-generator/security/code-scanning/4](https://github.com/NITHIN9526/certificate-generator/security/code-scanning/4)

In general, this kind of issue is fixed by ensuring that untrusted text is never passed directly into HTML-parsing sinks (`innerHTML`, jQuery `.html()`, etc.) without proper contextual encoding. Instead, use `textContent`/`innerText` or create DOM nodes and set their text parts, so user-controlled data is treated purely as text, not HTML.

For this specific case, the problematic line is:

```js
275:       certEvent.innerHTML = `has successfully participated in <strong>${p.event}</strong>`;
```

We want to keep the sentence and the `<strong>` styling, but ensure that `p.event` is treated as plain text. The safest way, without changing observable functionality, is:

1. Clear `certEvent`’s current content.
2. Add a text node for `"has successfully participated in "`.
3. Create a `<strong>` element.
4. Set `strong.textContent = p.event;` (so the event name is safely escaped).
5. Append the `<strong>` to `certEvent`.

This preserves the exact layout: plain text followed by a bold event name, but removes any interpretation of `p.event` as HTML. No new external libraries are needed; we just use standard DOM APIs (`document.createElement`, `document.createTextNode`). All other uses of `p` in this snippet (`certName.textContent`, `certDate.textContent`, `certIssuer.textContent`) are already safe because they use `textContent`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
